### PR TITLE
Support arbitrary torrc options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ hidden_services:
      hidden_service_ports:
         - [22, 22]
      hidden_service_private_key:
+
+hidden_services_configuration:
+  SocksPort: 9050
+  SocksPolicy: "reject *"
 ```
 
 Example Playbook
@@ -79,6 +83,18 @@ hidden_services:
       private
       key
       -----END RSA PRIVATE KEY-----
+
+hidden_services_configuration:
+  SocksPort: 9050
+  SocksPolicy: "reject *"
+  RunAsDaemon: 1
+  # Enabling Sandbox for the first time may prevent
+  # the tor service from restarting. Make sure your
+  # SSH connection is not over Tor when enabling it.
+  Sandbox: 1
+  FetchDirInfoEarly: 1
+  FetchDirInfoExtraEarly: 1
+  DataDirectory: /var/lib/tor
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,4 +10,7 @@ hidden_services:
         - [22, 22]
      hidden_service_private_key:
 
+hidden_services_configuration:
+  SocksPort: 9050
+  SocksPolicy: "reject *"
 

--- a/templates/torrc.j2
+++ b/templates/torrc.j2
@@ -59,6 +59,10 @@
 #HashedControlPassword 16:872860B76453A77D60CA2BB8C1A7042072093276A3D701AD684053EC4C
 #CookieAuthentication 1
 
+{% for key, value in hidden_services_configuration.iteritems() %}
+{{ key }} {{ value }}
+{% endfor %}
+
 ############### This section is just for location-hidden services ###
 
 ## Once you have configured a hidden service, you can look at the


### PR DESCRIPTION
As discussed in #8, implements support for all torrc general options via a new dict. Default vars for `hidden_service_configuration` are very light, and preserve default tor behavior.

Includes updates to README as well.
