### PR TITLE
Display hidden service URLs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,7 @@
     mode: 0700
     state: directory
   with_dict: "{{ hidden_service_services }}"
+  register: hidden_service_directory_creation_result
   when: item.value.hidden_service_state|default('present') == 'present'
 
 - name: ensure hidden service configuration is latest
@@ -71,6 +72,30 @@
     state: absent
   with_dict: "{{ hidden_service_services }}"
   when: item.value.hidden_service_state|default('present') == "absent"
+
+  # The hostname file won't be created until the tor service
+  # is reloaded, so bounce it before the `wait_for` task.
+- name: reload tor if service was created
+  service:
+    name: tor
+    state: reloaded
+  when: hidden_service_directory_creation_result|changed
+
+- name: wait for hidden service
+  wait_for:
+    path: "/var/lib/tor/{{ item.key }}/hostname"
+  with_dict: "{{ hidden_service_services }}"
+
+- name: read hidden service url
+  command: cat "/var/lib/tor/{{ item.key }}/hostname"
+  register: hidden_service_hostname_results
+  changed_when: false
+  with_dict: "{{ hidden_service_services }}"
+
+- name: display hidden service url
+  debug:
+    msg: >-
+      {{ lookup('template', role_path+'/templates/display_hostnames.j2') }}
 
 # dirty hack to stop tor, when server is not the current hidden service,  restart handler above , would start tor with same url and private key on two hosts
 - name: stop tor, if two servers are up, but only one should act as HS (for example jabber servers)

--- a/templates/display_hostnames.j2
+++ b/templates/display_hostnames.j2
@@ -1,0 +1,3 @@
+{% for hs in hidden_service_hostname_results.results %}
+A hidden service for /var/lib/tor/{{ hs.item.key }}/ was created or the address is not present in your vars file. It's reachable via '{{ hs.stdout }}'. Don't forget to add hostname and privatekey to your vars file.
+{% endfor %}


### PR DESCRIPTION
Adds a debug task to display Onion URLs at the end of the role run:

> TASK [ansible-role-hidden-service : reload tor if service was created] *********
> changed: [trusty]
> 
> TASK [ansible-role-hidden-service : wait for hidden service] *******************
> ok: [trusty] => (item={'value': {u'hidden_service_ports': [[22, 22]]}, 'key': u'ssh'})
> 
> TASK [ansible-role-hidden-service : read hidden service url] *******************
> ok: [trusty] => (item={'value': {u'hidden_service_ports': [[22, 22]]}, 'key': u'ssh'})
> 
> TASK [ansible-role-hidden-service : display hidden service url] ****************
> ok: [trusty] => {
>     "msg": "A hidden service for /var/lib/tor/ssh/ was created or the address is not present in your vars file. It's reachable via 'cz7j5xfncezf7iuv.onion'. Don't forget to add hostname and privatekey to your vars file.\n"
> }

The implementation uses a local template lookup and supports displaying info for multiple hosts without a bunch of `with_items` cruft, as discussed in #4:

> TASK [ansible-role-hidden-service : display hidden service url] ****************
> ok: [wheezy] => {
>     "msg": "A hidden service for /var/lib/tor/ssh/ was created or the address is not present in your vars file. It's reachable via 'pindqfgoknjpj7s4.onion'. Don't forget to add hostname and privatekey to your vars file.\n"
> }
> ok: [jessie] => {
>     "msg": "A hidden service for /var/lib/tor/ssh/ was created or the address is not present in your vars file. It's reachable via '43dxldm3aa2njo7m.onion'. Don't forget to add hostname and privatekey to your vars file.\n"
> }
> ok: [trusty] => {
>     "msg": "A hidden service for /var/lib/tor/ssh/ was created or the address is not present in your vars file. It's reachable via 'cz7j5xfncezf7iuv.onion'. Don't forget to add hostname and privatekey to your vars file.\n"
> }
> ok: [precise] => {
>     "msg": "A hidden service for /var/lib/tor/ssh/ was created or the address is not present in your vars file. It's reachable via 'ygj6kwr2xqzzh3pu.onion'. Don't forget to add hostname and privatekey to your vars file.\n"
> }

The implementation does not currently display the private key—it uses the text verbatim from #4—but it'd be trivial to update the local template to reformat the message. In fact, we could even make the message itself a default var that can be overridden and reference other role vars to support customization.

It also works reasonably well displaying the longer hostnames for Authenticated Tor Hidden Services in a testing branch, but that's best discussed in a separate issue.
