### PR TITLE
Adds ATHS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ hidden_service_services:
     hidden_service_ports:
       - [22, 22]
     hidden_service_authorized_clients:
-      - admin-{{ inventory_hostname }}
+      - admin
 
 hidden_services_configuration:
   SocksPort: 9050

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ hidden_service_services:
      hidden_service_hostname:
      hidden_service_ports:
         - [22, 22]
+     hidden_service_authorized_clients: []
      hidden_service_private_key:
 
 hidden_services_configuration:
@@ -83,6 +84,13 @@ hidden_service_services:
       private
       key
       -----END RSA PRIVATE KEY-----
+
+hidden_service_services:
+  ssh:
+    hidden_service_ports:
+      - [22, 22]
+    hidden_service_authorized_clients:
+      - admin-{{ inventory_hostname }}
 
 hidden_services_configuration:
   SocksPort: 9050

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ hidden_services_configuration:
   FetchDirInfoEarly: 1
   FetchDirInfoExtraEarly: 1
   DataDirectory: /var/lib/tor
+
+# Hosts that specified `hidden_service_authorized_clients` will generate
+# auth cookies for restricted access. Collect those values from the
+# hostname file and add them to the torrc for intended clients, e.g.
+# the Ansible controller, via the list var below.
+hidden_service_hid_serv_auth:
+  - "r7w3xdf3r5smxokv.onion p0xMVci7ffeQFA4IWkcBxR # client: admin"
 ```
 
 Testing & Development

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ hidden_service_services:
     hidden_service_hostname:
     hidden_service_ports:
       - [22, 22]
+    hidden_service_authorized_clients: []
 
 hidden_services_configuration:
   SocksPort: 9050

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,4 +14,8 @@ hidden_services_configuration:
   SocksPort: 9050
   SocksPolicy: "reject *"
 
+# List of auth cookies for connecting to Authenticated Tor Hidden Services.
+#
+hidden_service_hid_serv_auth: []
+
 hidden_service_monit_enabled: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,7 +90,7 @@
   register: hidden_service_hostname_results
   changed_when: false
   with_dict: "{{ hidden_service_services }}"
-  when: not item.value.hidden_service_hostname
+  when: not item.value.hidden_service_hostname|default(false)
 
 - name: display hidden service url
   debug:

--- a/templates/torrc.j2
+++ b/templates/torrc.j2
@@ -78,8 +78,10 @@ HiddenServiceDir /var/lib/tor/{{ servicename }}/
 {% for port in hsproperties['hidden_service_ports'] %}
 HiddenServicePort {{ port.0 }} {{ hidden_service_ipaddr }}:{{ port.1}}
 {% endfor %}
-
 {% endif %}
+{% for client in hsproperties['hidden_service_authorized_clients']|default([]) %}
+HiddenServiceAuthorizeClient stealth {{ client }}
+{% endfor %}
 {% endfor %}
 
 #HiddenServiceDir /var/lib/tor/other_hidden_service/

--- a/templates/torrc.j2
+++ b/templates/torrc.j2
@@ -60,7 +60,13 @@
 #CookieAuthentication 1
 
 {% for key, value in hidden_services_configuration.iteritems() %}
+{% if key == 'HidServAuth' %}
+{% for v in value %}
+HidServAuth {{ v }}
+{% endfor %}
+{% else %}
 {{ key }} {{ value }}
+{% endif %}
 {% endfor %}
 
 ############### This section is just for location-hidden services ###
@@ -78,6 +84,7 @@ HiddenServiceDir /var/lib/tor/{{ servicename }}/
 {% for port in hsproperties['hidden_service_ports'] %}
 HiddenServicePort {{ port.0 }} {{ hidden_service_ipaddr }}:{{ port.1}}
 {% endfor %}
+
 {% endif %}
 {% for client in hsproperties['hidden_service_authorized_clients']|default([]) %}
 HiddenServiceAuthorizeClient stealth {{ client }}

--- a/templates/torrc.j2
+++ b/templates/torrc.j2
@@ -60,14 +60,12 @@
 #CookieAuthentication 1
 
 {% for key, value in hidden_services_configuration.iteritems() %}
-{% if key == 'HidServAuth' %}
-{% for v in value %}
-HidServAuth {{ v }}
-{% endfor %}
-{% else %}
 {{ key }} {{ value }}
-{% endif %}
 {% endfor %}
+
+{% for client in hidden_service_hid_serv_auth -%}
+HidServAuth {{ client }}
+{% endfor -%}
 
 ############### This section is just for location-hidden services ###
 


### PR DESCRIPTION
See rationale in #12. Succinctly, enables an extra layer of authentication for hidden services intended to have only selective availability, e.g. SSH. Clients will need to update their torrc files with the corresponding `HidServAuth` line in order to connect to the ATHS. (It's not right for everything, clearly, but it's very nice to have for SSH in particular.)

To enable it, add a list var `hidden_service_authorized_clients` to the services configuration:

```
hidden_service_services:
  ssh:
    hidden_service_ports:
      - [22, 22]
    hidden_service_authorized_clients:
      - admin-{{ inventory_hostname }}
```

Plays nicely with #11, in that the `hostname` file is still displayed in its entirety, including:
- the Onion URL
- the auth cookie that needs to go in the client torrc
- a comment with name of the authorized client

Appending inventory_hostname in the authorized_client var causes the comment in the hostname config to render as e.g. `# client: admin-www.example.com`, which greatly helps when managing auth cookies for multiple hosts.

Closes #12.
