### PR TITLE
Installs deb.torproject.org-keyring package by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 hidden_service_active: True
 hidden_service_ipaddr: 127.0.0.1
 hidden_service_tor_apt_state: present
+hidden_service_apt_packages: ['deb.torproject.org-keyring']
 hidden_service_services:
   ssh:
     hidden_service_hostname:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: ensure the repository key is present
   apt_key:
     data: "{{ lookup('file', 'torproject.asc') }}"
+    # Explicitly declaring keyring path to match what's configured by the
+    # `deb.torproject.org-keyring` package.
+    keyring: /etc/apt/trusted.gpg.d/deb.torproject.org-keyring.gpg
     state: present
 
 - name: ensure the required repository is present
@@ -12,6 +15,12 @@
   apt:
     pkg: tor
     state: "{{ hidden_service_tor_apt_state }}"
+
+- name: install extra tor packages
+  apt:
+    pkg: "{{ item }}"
+    state: present
+  with_items: "{{ hidden_service_apt_packages }}"
 
 - name: ensure hidden service directory is present
   file:


### PR DESCRIPTION
Creates new role var `hidden_service_apt_packages` with a single
member by default: `deb.torproject.org-keyring`. Updates the apt_key
task to install to a specific keyring dedicated to the Tor Project
signing key. The postinst script on the keyring package will
automatically remove tor keys from the general apt keyring
(/etc/apt/trusted.gpg), so no special cleanup tasks are required.

Since the package list is now a role default, the list can be overridden
to support additional tor-related packages as required.

Closes #14.